### PR TITLE
Fixed the hover problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,13 +9,15 @@
 
 <body>
     <div id="teapic">
-        <a href="./test.html"></a>
+        <a href="./test.html" class="main-enterance">
+            <div></div>
+        </a>
         <section>
-        <p id="small">An interative story about Chinese tea culture.</p>
-        <p>Yichi (Lyric) Liu | lyricliu@gatech.edu | LIU TWINE EXERCISE </p>
-    </section>
+            <p id="small">An interative story about Chinese tea culture.</p>
+            <p>Yichi (Lyric) Liu | lyricliu@gatech.edu | LIU TWINE EXERCISE </p>
+        </section>
     </div>
-    
+
 </body>
 
 </html>

--- a/teatable.css
+++ b/teatable.css
@@ -22,20 +22,26 @@ p {
     display: flex;
 }
 
-#teapic a {
+.main-enterance {
     display: block;
     width: 241px;
     height: 241px;
-    background: url(./img/startbutton1.png) no-repeat center;
     background-size: 239px;
     margin: auto;
     transition: transform 0.5s;
 }
 
-#teapic a:hover {
+.main-enterance div {
+    width: 241px;
+    height: 241px;
+    background: url(./img/startbutton1.png) no-repeat center;
+    transition: transform .5s ease-in-out, background 0s linear .25s;
+}
+
+.main-enterance:hover div {
     background: url(./img/startbutton2.png) no-repeat center;
     transform: rotateX(180deg);
-    transition: transform 0.5s;
+    transition: transform .5s ease-in-out, background 0s linear .25s;
 }
 
 a {
@@ -48,11 +54,13 @@ section {
     font-size: 20px;
     font-family: Calibri;
     top: 610px;
-    margin-left:12px;
-
+    margin-left: 12px;
 }
 
 p {
     color: #c1ac9e;
 }
-#small{font-size: 16px;}
+
+#small {
+    font-size: 16px;
+}


### PR DESCRIPTION
这个问题其实是这样：

你鼠标放上去以后那个链接就会 `tramsform` 嘛，然后翻转的 `transform` 是会改变元素的大小位置的，于是它改变大小的时候，浏览器就认为你的鼠标移出了这个元素，于是就发生了这样的惨剧。解决办法就当然只能在一个固定的元素里面套一个负责呈现翻转视觉效果的元素，然后让外面固定的元素负责事件触发，这样子世界就和平了。

顺便给你的动画做了一点改良，这样会不会更接近真实的翻牌子效果呢 :)

看到你现在使用 Git 的习惯比我还好（主要是因为我懒，不愿意建那么多 branch ），我表示很欣慰。

不过仍然有一点建议，一是文件的目录还可以更清晰一些，把 CSS 和 JavaScript 各自单独放一个文件夹，这样方便后期管理；二是在 Markdown 里面插入图片其实有类似这样 `![图片标题(图片地址)` 的写法，没必要用 HTML 标签。

以上。
